### PR TITLE
[Sikkerhet] Oppdaterer beskrivelse.yaml fra versjon 1.0 til 3.0 og oppretter catalog-info.yaml

### DIFF
--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,2 +1,5 @@
-version: 1.0
-organisasjon: Land
+version: 3.0
+organization: Land
+product: Tjenester
+repo_types: [Documentation]
+platforms: []

--- a/.sikkerhet/beskrivelse.yaml
+++ b/.sikkerhet/beskrivelse.yaml
@@ -1,5 +1,5 @@
 version: 3.0
 organization: Land
 product: Tjenester
-repo_types: [Documentation]
+repo_types: [Experiment]
 platforms: []

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -3,11 +3,10 @@ apiVersion: "backstage.io/v1alpha1"
 kind: "Component"
 metadata:
   name: "tjenestedokumentasjon"
-  tags:
-  - "public"
+  tags: []
 spec:
-  type: "documentation"
-  lifecycle: "production"
+  type: "experiment"
+  lifecycle: "experiment"
   owner: "datadeling_og_distribusjon"
   system: "tjenester"
 ---

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,38 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "tjenestedokumentasjon"
+  tags:
+  - "public"
+spec:
+  type: "documentation"
+  lifecycle: "production"
+  owner: "datadeling_og_distribusjon"
+  system: "tjenester"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Group"
+metadata:
+  name: "security_champion_tjenestedokumentasjon"
+  title: "Security Champion tjenestedokumentasjon"
+spec:
+  type: "security_champion"
+  parent: "land_security_champions"
+  members:
+  - "carsmie"
+  children:
+  - "resource:tjenestedokumentasjon"
+---
+apiVersion: "backstage.io/v1alpha1"
+kind: "Resource"
+metadata:
+  name: "tjenestedokumentasjon"
+  links:
+  - url: "https://github.com/kartverket/tjenestedokumentasjon"
+    title: "tjenestedokumentasjon på GitHub"
+spec:
+  type: "repo"
+  owner: "security_champion_tjenestedokumentasjon"
+  dependencyOf:
+  - "component:tjenestedokumentasjon"


### PR DESCRIPTION
Denne PRen oppdaterer `.sikkerhet/beskrivelse.yaml` til versjon 3.0. Det innebærer at feltene nå blir på engelsk i stedet for norsk. Følgende felter legges inn:

- `version: 3.0`
- `organization: Land`
- `product: Tjenester`
- `repo_types: [Documentation]`
- `platforms: []`

Videre oppdaterer denne PRen `catalog-info.yaml` for å gi entiteter til Backstage.

Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.