### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @carsmie
+/.security/ @carsmie

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: Land
 product: Tjenester
 repo_types: [Experiment]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,29 +9,3 @@ spec:
   lifecycle: "experiment"
   owner: "datadeling_og_distribusjon"
   system: "tjenester"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_tjenestedokumentasjon"
-  title: "Security Champion tjenestedokumentasjon"
-spec:
-  type: "security_champion"
-  parent: "land_security_champions"
-  members:
-  - "carsmie"
-  children:
-  - "resource:tjenestedokumentasjon"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "tjenestedokumentasjon"
-  links:
-  - url: "https://github.com/kartverket/tjenestedokumentasjon"
-    title: "tjenestedokumentasjon på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_tjenestedokumentasjon"
-  dependencyOf:
-  - "component:tjenestedokumentasjon"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml